### PR TITLE
docs: document iptables port redirect for browser access

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ Add the following line to `/etc/hosts` so your browser resolves `to` to localhos
 127.0.0.1 to
 ```
 
+## One-time port redirect setup
+
+The service listens on port 4080, but browsers connect to port 80 for plain `http://` URLs. Redirect port 80 to 4080 with iptables:
+
+```bash
+sudo iptables -t nat -A OUTPUT -d 127.0.0.1 -p tcp --dport 80 -j REDIRECT --to-ports 4080
+```
+
+To persist the rule across reboots:
+
+```bash
+sudo apt install iptables-persistent
+sudo netfilter-persistent save
+```
+
+After this, `http://to/gh` works in your browser. Once you have visited any `http://to/…` URL, Chrome learns that `to` is a real host and you can drop the `http://` prefix — bare `to/gh` will navigate directly without searching.
+
 ## Build and install
 
 ```bash


### PR DESCRIPTION
## Summary

- Documents the iptables rule to redirect port 80 → 4080 so `http://to/gh` works without specifying a port
- Explains how to persist the rule across reboots with `iptables-persistent`
- Notes Chrome's hostname-learning behavior so bare `to/gh` (without `http://`) works after the first visit

## Test plan

- [ ] Follow the new iptables section on a fresh install and verify `http://to/gh` navigates correctly
- [ ] Visit `http://to/gh` once, then confirm bare `to/gh` navigates instead of searching

🤖 Generated with [Claude Code](https://claude.com/claude-code)