### PR TITLE
Resolve #24: feat(server): forward subpath remainder to stored URL

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -27,14 +27,40 @@ func (sv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		sv.adminHandler(w, r)
 		return
 	}
-	shortcut := strings.TrimPrefix(r.URL.Path, "/")
-	if shortcut != "" {
-		if url, ok := sv.s.Get(shortcut); ok {
-			http.Redirect(w, r, url, http.StatusFound)
+	path := strings.TrimPrefix(r.URL.Path, "/")
+	if path != "" {
+		if target, remainder, ok := sv.resolve(path); ok {
+			location := target
+			if remainder != "" {
+				location += "/" + remainder
+			}
+			if r.URL.RawQuery != "" {
+				location += "?" + r.URL.RawQuery
+			}
+			if fragment := r.URL.EscapedFragment(); fragment != "" {
+				location += "#" + fragment
+			}
+			http.Redirect(w, r, location, http.StatusFound)
 			return
 		}
 	}
 	http.Redirect(w, r, "/.tolink/", http.StatusFound)
+}
+
+// resolve finds the longest stored shortcut that is a segment-aligned prefix of path.
+// It returns the stored URL, the remainder after the matched prefix, and whether a match was found.
+func (sv *Server) resolve(path string) (string, string, bool) {
+	candidate := path
+	for {
+		if url, ok := sv.s.Get(candidate); ok {
+			return url, strings.TrimPrefix(path[len(candidate):], "/"), true
+		}
+		idx := strings.LastIndex(candidate, "/")
+		if idx == -1 {
+			return "", "", false
+		}
+		candidate = candidate[:idx]
+	}
 }
 
 func (sv *Server) adminHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -39,6 +39,113 @@ func TestKnownShortcutRedirect(t *testing.T) {
 	}
 }
 
+func TestSubpathRemainderForwarded(t *testing.T) {
+	sv := newTestServer(t)
+	if err := sv.s.Set("gh", "https://github.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/gh/trending", nil)
+	w := httptest.NewRecorder()
+	sv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("expected 302, got %d", w.Code)
+	}
+	if got := w.Header().Get("Location"); got != "https://github.com/trending" {
+		t.Errorf("expected Location https://github.com/trending, got %q", got)
+	}
+}
+
+func TestMultiSegmentRemainderForwarded(t *testing.T) {
+	sv := newTestServer(t)
+	if err := sv.s.Set("gh", "https://github.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/gh/charleszheng44/tolink", nil)
+	w := httptest.NewRecorder()
+	sv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("expected 302, got %d", w.Code)
+	}
+	if got := w.Header().Get("Location"); got != "https://github.com/charleszheng44/tolink" {
+		t.Errorf("expected Location https://github.com/charleszheng44/tolink, got %q", got)
+	}
+}
+
+func TestQueryStringPassthrough(t *testing.T) {
+	sv := newTestServer(t)
+	if err := sv.s.Set("gh", "https://github.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/gh/trending?tab=daily", nil)
+	w := httptest.NewRecorder()
+	sv.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Location"); got != "https://github.com/trending?tab=daily" {
+		t.Errorf("expected Location https://github.com/trending?tab=daily, got %q", got)
+	}
+}
+
+func TestFragmentPassthrough(t *testing.T) {
+	sv := newTestServer(t)
+	if err := sv.s.Set("gh", "https://github.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/gh/trending?tab=daily#readme", nil)
+	w := httptest.NewRecorder()
+	sv.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Location"); got != "https://github.com/trending?tab=daily#readme" {
+		t.Errorf("expected Location https://github.com/trending?tab=daily#readme, got %q", got)
+	}
+}
+
+func TestLongestPrefixWins(t *testing.T) {
+	sv := newTestServer(t)
+	if err := sv.s.Set("gh", "https://github.com"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sv.s.Set("gh/me", "https://github.com/charleszheng44"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/gh/me", nil)
+	w := httptest.NewRecorder()
+	sv.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Location"); got != "https://github.com/charleszheng44" {
+		t.Errorf("expected longest-prefix match to win, got %q", got)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/gh/me/tolink", nil)
+	w = httptest.NewRecorder()
+	sv.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Location"); got != "https://github.com/charleszheng44/tolink" {
+		t.Errorf("expected longest-prefix match with remainder, got %q", got)
+	}
+}
+
+func TestMultiSegmentUnknownFallsThroughToAdmin(t *testing.T) {
+	sv := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/unknown/path", nil)
+	w := httptest.NewRecorder()
+	sv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("expected 302, got %d", w.Code)
+	}
+	if got := w.Header().Get("Location"); got != "/.tolink/" {
+		t.Errorf("expected Location /.tolink/, got %q", got)
+	}
+}
+
 func TestUnknownShortcutRedirectsToAdmin(t *testing.T) {
 	sv := newTestServer(t)
 


### PR DESCRIPTION
Closes #24