### PR TITLE
Resolve #27: Add macOS support (LaunchAgent + pf redirect)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,39 @@
 .PHONY: build install clean uninstall
 
+UNAME := $(shell uname -s)
+
 build:
 	go build -o bin/tolink ./cmd/tolink
 	go build -o bin/tolinkctl ./cmd/tolinkctl
 
 install: build
+ifeq ($(UNAME),Darwin)
+	sudo cp bin/tolink /usr/local/bin/tolink
+	sudo cp bin/tolinkctl /usr/local/bin/tolinkctl
+	mkdir -p $(HOME)/Library/LaunchAgents
+	cp tolink.plist $(HOME)/Library/LaunchAgents/com.charleszheng44.tolink.plist
+	launchctl unload $(HOME)/Library/LaunchAgents/com.charleszheng44.tolink.plist 2>/dev/null || true
+	launchctl load $(HOME)/Library/LaunchAgents/com.charleszheng44.tolink.plist
+else
 	sudo cp bin/tolink /usr/local/bin/tolink
 	sudo cp bin/tolinkctl /usr/local/bin/tolinkctl
 	sudo cp tolink.service /etc/systemd/system/tolink.service
 	sudo systemctl daemon-reload
 	sudo systemctl enable tolink
 	sudo systemctl is-active --quiet tolink && sudo systemctl restart tolink || sudo systemctl start tolink
+endif
 
 clean:
 	rm -rf bin/
 
 uninstall:
+ifeq ($(UNAME),Darwin)
+	launchctl unload $(HOME)/Library/LaunchAgents/com.charleszheng44.tolink.plist 2>/dev/null || true
+	rm -f $(HOME)/Library/LaunchAgents/com.charleszheng44.tolink.plist
+	sudo rm -f /usr/local/bin/tolink /usr/local/bin/tolinkctl
+else
 	sudo systemctl stop tolink || true
 	sudo systemctl disable tolink || true
 	sudo rm -f /usr/local/bin/tolink /usr/local/bin/tolinkctl /etc/systemd/system/tolink.service
 	sudo systemctl daemon-reload
+endif

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ tolink is a local-only URL shortcut service. Add a shortcut like `gh → https:/
 ## Prerequisites
 
 - Go 1.21+
-- Linux with systemd
+- Linux with systemd, or macOS
 
 ## One-time `/etc/hosts` setup
 
@@ -15,7 +15,7 @@ Add the following line to `/etc/hosts` so your browser resolves `to` to localhos
 127.0.0.1 to
 ```
 
-## One-time port redirect setup
+## One-time port redirect setup (Linux)
 
 The service listens on port 4080, but browsers connect to port 80 for plain `http://` URLs. Redirect port 80 to 4080 with iptables:
 
@@ -29,6 +29,29 @@ To persist the rule across reboots:
 sudo apt install iptables-persistent
 sudo netfilter-persistent save
 ```
+
+## One-time port redirect setup (macOS)
+
+Create the anchor file `/etc/pf.anchors/com.tolink`:
+
+```
+rdr pass on lo0 inet proto tcp from any to 127.0.0.1 port 80 -> 127.0.0.1 port 4080
+```
+
+Append to `/etc/pf.conf`:
+
+```
+rdr-anchor "com.tolink"
+load anchor "com.tolink" from "/etc/pf.anchors/com.tolink"
+```
+
+Enable pf and load the rules:
+
+```bash
+sudo pfctl -ef /etc/pf.conf
+```
+
+These persist across reboots because pf reads `/etc/pf.conf` at boot.
 
 After this, `http://to/gh` works in your browser. Once you have visited any `http://to/…` URL, Chrome learns that `to` is a real host and you can drop the `http://` prefix — bare `to/gh` will navigate directly without searching.
 

--- a/tolink.plist
+++ b/tolink.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.charleszheng44.tolink</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/tolink</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/tmp/tolink.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/tolink.err.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #27

## Summary
- Run tolink on macOS via a per-user LaunchAgent (`~/Library/LaunchAgents/com.charleszheng44.tolink.plist`) that auto-starts at login
- `make install` / `make uninstall` now branch on `uname -s` — Linux path unchanged, macOS path uses `launchctl`
- README documents the macOS pf redirect parallel to the existing Linux iptables block
- No Go source changes; daemon and `tolinkctl` already work on macOS

## Test plan
- [ ] `go test ./...` passes on macOS
- [ ] `make build` produces working binaries on macOS
- [ ] `make install` loads the LaunchAgent and the daemon serves `http://127.0.0.1:4080/.tolink/`
- [ ] After one-time pf setup from README, `http://to/gh` redirects to the configured target
- [ ] `make uninstall` removes the plist, the binaries, and stops the daemon with no residue
- [ ] On Linux, `make install`/`uninstall` behave identically to before this change