### PR TITLE
fix(macos): enable pf at boot via LaunchDaemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ ifeq ($(UNAME),Darwin)
 	cp tolink.plist $(HOME)/Library/LaunchAgents/com.charleszheng44.tolink.plist
 	launchctl unload $(HOME)/Library/LaunchAgents/com.charleszheng44.tolink.plist 2>/dev/null || true
 	launchctl load $(HOME)/Library/LaunchAgents/com.charleszheng44.tolink.plist
+	sudo cp tolink-pf.plist /Library/LaunchDaemons/com.charleszheng44.tolink.pf.plist
+	sudo launchctl unload /Library/LaunchDaemons/com.charleszheng44.tolink.pf.plist 2>/dev/null || true
+	sudo launchctl load /Library/LaunchDaemons/com.charleszheng44.tolink.pf.plist
 else
 	sudo cp bin/tolink /usr/local/bin/tolink
 	sudo cp bin/tolinkctl /usr/local/bin/tolinkctl
@@ -30,6 +33,8 @@ uninstall:
 ifeq ($(UNAME),Darwin)
 	launchctl unload $(HOME)/Library/LaunchAgents/com.charleszheng44.tolink.plist 2>/dev/null || true
 	rm -f $(HOME)/Library/LaunchAgents/com.charleszheng44.tolink.plist
+	sudo launchctl unload /Library/LaunchDaemons/com.charleszheng44.tolink.pf.plist 2>/dev/null || true
+	sudo rm -f /Library/LaunchDaemons/com.charleszheng44.tolink.pf.plist
 	sudo rm -f /usr/local/bin/tolink /usr/local/bin/tolinkctl
 else
 	sudo systemctl stop tolink || true

--- a/README.md
+++ b/README.md
@@ -45,13 +45,7 @@ rdr-anchor "com.tolink"
 load anchor "com.tolink" from "/etc/pf.anchors/com.tolink"
 ```
 
-Enable pf and load the rules:
-
-```bash
-sudo pfctl -ef /etc/pf.conf
-```
-
-These persist across reboots because pf reads `/etc/pf.conf` at boot.
+Then run `make install` (see below). The Makefile installs a LaunchDaemon at `/Library/LaunchDaemons/com.charleszheng44.tolink.pf.plist` that runs `pfctl -ef /etc/pf.conf` at boot, so the redirect persists across reboots. Loading the LaunchDaemon during install also enables pf immediately, so no separate `pfctl` command is needed.
 
 After this, `http://to/gh` works in your browser. Once you have visited any `http://to/…` URL, Chrome learns that `to` is a real host and you can drop the `http://` prefix — bare `to/gh` will navigate directly without searching.
 

--- a/tolink-pf.plist
+++ b/tolink-pf.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.charleszheng44.tolink.pf</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/sbin/pfctl</string>
+    <string>-ef</string>
+    <string>/etc/pf.conf</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/tolink-pf.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/tolink-pf.err.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds `tolink-pf.plist`, a system LaunchDaemon that runs `pfctl -ef /etc/pf.conf` once at boot so the `:80 → :4080` rdr rule survives reboots on macOS
- Wires install/uninstall of the LaunchDaemon into the macOS branch of the `Makefile`
- Corrects the README's incorrect claim that the rdr rules persist across reboots simply because they live in `/etc/pf.conf`

## Why
After a reboot, `http://to/...` was returning connection-refused while the tolink daemon itself was still running on `127.0.0.1:4080`. Investigation showed `/etc/pf.anchors/com.tolink` and the `/etc/pf.conf` edits were intact, but pf itself was not enabled — macOS does not auto-enable pf at boot for user-defined anchors. The original `sudo pfctl -ef /etc/pf.conf` only enabled pf for the current session.

## Test plan
- [x] `plutil -lint tolink-pf.plist` returns OK
- [x] After `sudo cp tolink-pf.plist /Library/LaunchDaemons/...` and `sudo launchctl load ...`, `curl http://to/.tolink/` returns 200 (verified on the affected host)
- [x] Reboot and confirm `curl http://to/.tolink/` returns 200 without any manual `pfctl` command
- [x] `make uninstall` removes both the LaunchAgent and the new LaunchDaemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)